### PR TITLE
Fix new project dialog - set ListBox color

### DIFF
--- a/NightOwl.vstheme
+++ b/NightOwl.vstheme
@@ -8150,7 +8150,7 @@
         <Foreground Type="CT_RAW" Source="FFE0F6FF" />
       </Color>
       <Color Name="ListBox">
-        <Background Type="CT_RAW" Source="FFFBFBFB" />
+        <Background Type="CT_RAW" Source="FF011627" />
         <Foreground Type="CT_RAW" Source="FF1E1E1E" />
       </Color>
       <Color Name="ListBoxBorder">


### PR DESCRIPTION
Hi, I've fixed the new project dialog. It turns out its property is called "ListBox" 🤷‍♂️

I've figured out today that you can find out the names of some elements by taking a screenshot, checking the color of a given element with the color picker and then searching for that element using a hex code.

(fixes #1)